### PR TITLE
Adding fix for non-unique ids in task cache dict

### DIFF
--- a/ept/ept.py
+++ b/ept/ept.py
@@ -88,7 +88,7 @@ class EPT(object):
         return o
 
     async def adata(self):
-        limit = 100
+        limit = 10
         connector = aiohttp.TCPConnector(limit=None)
         async with aiohttp.ClientSession(connector=connector) as session, TaskPool(limit) as tasks:
 


### PR DESCRIPTION
closes #2 

The call to `id` was returning non-unique ids. From the docs:
> This is guaranteed to be unique among simultaneously existing objects.

Because we're using asyncio the coroutines don't exist simultaneously (?). I switched to using the task name from the future as an id and that seems to be unique.