### PR TITLE
Add query param forwarding with a test

### DIFF
--- a/ept/endpoint.py
+++ b/ept/endpoint.py
@@ -18,8 +18,9 @@ class Driver(object):
 
 
 class Http(Driver):
-    def __init__(self, root):
+    def __init__(self, root, query=None):
         super(Http, self).__init__(root)
+        self.query = query
 
     async def download(self, session, url):
         async with session.get(url) as response:
@@ -27,6 +28,8 @@ class Http(Driver):
 
     async def get(self, part, session=None, tpool=None):
         url = self.root + part
+        if self.query is not None:
+            url += '?' + self.query
         if tpool:
             return await tpool.put(self.download(session, url))
         if session:
@@ -65,12 +68,13 @@ class File(Driver):
 
 
 class Endpoint(object):
-    def __init__(self, root):
+    def __init__(self, root, query=None):
         self.root = root
+        self.query = query
 
-        if "http" in root or "https" in root:
+        if root.startswith("http://") or root.startswith("https://"):
             self.remote = True
-            self.driver = Http(root)
+            self.driver = Http(root, query)
         else:
             self.remote = False
             self.driver = File(root)

--- a/ept/ept.py
+++ b/ept/ept.py
@@ -18,6 +18,9 @@ from .laz import LAZ
 
 class EPT(object):
     def __init__(self, url, bounds=None, queryResolution=None):
+        query = None
+        if ('?' in url):
+            [url, query] = url.split('?', 1)
 
         if url.endswith("/"):
             url = url[:-1]
@@ -28,13 +31,14 @@ class EPT(object):
             path = os.path.dirname(p.path)
             url = urljoin(url, path, "/")
 
+        self.query = query
         self.root_url = url
         self.key = Key()
         self.overlaps_dict = {}
         self.depthEnd = None
         self.queryResolution = queryResolution
         self.queryBounds = bounds
-        self.endpoint = Endpoint(self.root_url)
+        self.endpoint = Endpoint(self.root_url, self.query)
         self.info = self.get_info()
         self.computedDepth = False
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup_args = dict(
         "lazrs>=0.3.1",
         "pyproj>=3.2.0",
         "numpy>=1.21",
-        "aiohttp>=3.7",
+        "aiohttp==3.7.4", # https://github.com/aio-libs/aiohttp/issues/5394
         "aiofiles>=0.7.0",
         "requests>=2.26.0",
     ],

--- a/test/test_endpoint.py
+++ b/test/test_endpoint.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 from ept.endpoint import Endpoint
@@ -5,7 +6,6 @@ from ept.endpoint import Endpoint
 class TestRemoteEndpoint(unittest.TestCase):
 
     def setUp(self):
-#        self.e = Endpoint('http://entwine.io/data/ept-star')
         self.e = Endpoint('https://raw.githubusercontent.com/PDAL/data/master/entwine/data/ept-star/')
 
     def test_info(self):
@@ -14,6 +14,21 @@ class TestRemoteEndpoint(unittest.TestCase):
     def test_fetch(self):
         d = self.e.get('/ept.json').replace(b"\r", b"")
         self.assertEqual(len(d), 2192)
+
+class TestQueryParamEndpoint(unittest.TestCase):
+
+    def setUp(self):
+        self.e = Endpoint('https://httpbin.org', 'q=42')
+
+    def test_info(self):
+        self.assertEqual(self.e.remote, True)
+        self.assertEqual(self.e.query, 'q=42')
+
+    def test_fetch(self):
+        j = json.loads(self.e.get('/anything'))
+        # Our query parameters are parsed out into response.args.q, make sure
+        # that they are forwarded properly.
+        self.assertEqual(j['args']['q'], '42')
 
 class TestLocalEndpoint(unittest.TestCase):
 


### PR DESCRIPTION
If an EPT endpoint URL is specified with query params, pluck them out and forward them with all fetches from the remote endpoint.  This is useful for things like query-authenticated EPT endpoints.

Also adds a more robust check for determining whether an endpoint is remote or not, and pins the aiohttp version to overcome an [issue](https://github.com/aio-libs/aiohttp/issues/5394) I ran into which was causing remote requests to hang.