### PR TITLE
Update aiohttp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 build
 dist
 ept.egg-info/
+ept_python.egg-info/
 VERSION.txt
 __pycache__/

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup_args = dict(
         "lazrs>=0.3.1",
         "pyproj>=3.2.0",
         "numpy>=1.21",
-        "aiohttp>=3.8.3",
+        "aiohttp>=3.8.0",
         "aiofiles>=0.7.0",
         "requests>=2.26.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup_args = dict(
         "lazrs>=0.3.1",
         "pyproj>=3.2.0",
         "numpy>=1.21",
-        "aiohttp==3.7.4", # https://github.com/aio-libs/aiohttp/issues/5394
+        "aiohttp>=3.8.3",
         "aiofiles>=0.7.0",
         "requests>=2.26.0",
     ],


### PR DESCRIPTION
Firstly, thank you for this package! I've been utilising ept-python in another project, and the hard pinning of aiohttp causes conflicts with other packages, e.g. awswrangler.

I have run the tests against this more recent version of aiohttp, and there are no issues, I assume the referenced github issue was solved by the intervening releases.

Was there any issues related to this version that aren't covered by the tests?